### PR TITLE
Replaced macro w/ constants

### DIFF
--- a/src/openfiles.cpp
+++ b/src/openfiles.cpp
@@ -18,7 +18,7 @@
 #include "treeview.h"
 
 #ifndef NI_IDN
-#define NI_IDN 0
+const int NI_IDN = 0;
 #endif
 
 enum

--- a/src/procdialogs.h
+++ b/src/procdialogs.h
@@ -27,11 +27,11 @@
    are scaled back to these limits. So show these limits in the slider
 */
 #ifdef __linux__
-#define RENICE_VAL_MIN -20
-#define RENICE_VAL_MAX 19
+const int RENICE_VAL_MIN = -20;
+const int RENICE_VAL_MAX = 19;
 #else /* ! linux */
-#define RENICE_VAL_MIN -20
-#define RENICE_VAL_MAX 20
+const int RENICE_VAL_MIN = -20;
+const int RENICE_VAL_MAX = 20;
 #endif
 
 


### PR DESCRIPTION
This patch replaces a multitude of compile-time macros (ewww). Macro values are now constants and macro instructions became lambdas.
